### PR TITLE
docs: fix gsl-complex* typo in gsl-complex.rst

### DIFF
--- a/doc/source/gsl-complex.rst
+++ b/doc/source/gsl-complex.rst
@@ -33,7 +33,7 @@ Complex numbers
 
    :value complex:
 
-      A :class:`<gsl-complex*>`.
+      A :class:`<gsl-complex>`.
 
    :description:
 
@@ -62,7 +62,7 @@ Complex numbers
 
    :parameter complex:
 
-      A :class:`<gsl-complex*>`. The complex number.
+      A :class:`<gsl-complex>`. The complex number.
 
    :value real:
 


### PR DESCRIPTION
Fixes #12 — fix `<gsl-complex*\>` to `<gsl-complex>` in doc/source/gsl-complex.rst (lines 36 and 65). The `<gsl-complex*\>` reference was incorrect; the correct class name is `<gsl-complex>`.